### PR TITLE
Add `x.com`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
 	"permissions": [
 		"webRequest",
 		"webRequestBlocking",
-		"https://twitter.com/"
+		"https://twitter.com/",
+		"https://x.com/"
 	],
 
 	"background": {

--- a/unfuck.js
+++ b/unfuck.js
@@ -3,7 +3,7 @@ const tracking_params = ["s", "t"];
 function unfuck(request) {
 	var unfuckedURL = new URL(request.url);
 	if (tracking_params.some(unfuckedURL.searchParams.has, unfuckedURL.searchParams)) {
-		tracking_params.map(unfuckedURL.searchParams.delete, unfuckedURL.searchParams);
+		tracking_params.forEach((e) => unfuckedURL.searchParams.delete(e));
 		console.log("Removed twitter tracking");
 		return {
 			redirectUrl: unfuckedURL.toString()
@@ -14,7 +14,10 @@ function unfuck(request) {
 browser.webRequest.onBeforeRequest.addListener(
 	unfuck,
 	{
-		urls: ["*://*.twitter.com/*/status/*"],
+		urls: [
+			"*://*.twitter.com/*/status/*",
+			"*://*.x.com/*/status/*"
+		],
 		types: ["main_frame"],
 	},
 	["blocking"]


### PR DESCRIPTION
The apps are starting to give out `x.com` links, it would be good to strip it before it hits their servers for the redirect.

Also apparently map()s with side effects are bad and this actually works for t= oops